### PR TITLE
 Add Redhat support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,9 @@
 ---
-- name: Install dependencies
-  apt:
-    pkg: ["git", "curl", "build-essential", "libssl-dev"]
-    update_cache: yes
-    cache_valid_time: 3600
-  become: true
-  tags: nvm
+- include: setup-redhat.yml
+  when: ansible_os_family == "RedHat"
+
+- include: setup-debian.yml
+  when: ansible_os_family == "Debian"
 
 - name: Install nvm {{ nvm_version }}
   git:

--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -1,0 +1,15 @@
+---
+- name: Install dependencies
+  become: true
+  become_user: root
+  tags: nvm
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+    name: "{{ packages }}"
+  vars:
+    packages:
+    - git
+    - curl
+    - build-essential
+    - libssl-dev

--- a/tasks/setup-redhat.yml
+++ b/tasks/setup-redhat.yml
@@ -1,0 +1,13 @@
+---
+- name: Install dependencies
+  become: true
+  become_user: root
+  tags: nvm
+  yum:
+    name: "{{ packages }}"
+  vars:
+    packages:
+    - "@Development Tools"
+    - git
+    - curl
+    - openssl-devel


### PR DESCRIPTION
This adds support for the RedHat OS family.

Note that I added `become_user: root`. The reason is that I want to be able to execute the role as a non-root user. Since NVM is intended to be installed from a (non-root) user context, it seems to make sense to run it like so:

```yml
---
- become: yes
  ...
  roles:
    ...
    - role: ansible-nvm
      nvm_node_version: 12.12
      become: yes
      become_user: "{{ deploy_user }}"
```

where the `ansible-nvm` tasks are carried out as `deploy_user`. The NVM folder is then created int he right place without having to set `nvm_install_path` manually (and fix permissions manually afterwards) and the correct `.profile` file is updated.
