### PR TITLE
Make ~/.profile configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Role Variables
 * `nvm_version` nvm version tag, or `HEAD`. Defaults to `0.34.0`
 * `nvm_node_version` Node.js version. Defaults to `10.16.2`
 * `nvm_install_path` nvm folder path. Defaults to `~/.nvm`
+* `nvm_shell_init_file` The Shell initialization file to add sourcing of NVM to. Defaults to `~/.profile`
 
 Dependencies
 ------------
@@ -28,6 +29,7 @@ Example Playbook
         - role: stephdewit.nvm
           nvm_version: 0.4.0
           nvm_node_version: 0.10
+          nvm_shell_init_file: ~/.bashrc
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 nvm_version: 0.34.0
 nvm_node_version: 10.16.2
 nvm_install_path: ~/.nvm
+nvm_shell_init_file: ~/.profile

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,27 +14,27 @@
     version: "{% if nvm_version!='HEAD' %}v{% endif %}{{ nvm_version }}"
   tags: nvm
 
-- name: Source nvm in ~/.profile
+- name: Update nvm_shell_init_file to source nvm
   lineinfile:
-    dest: ~/.profile
+    dest: "{{ nvm_shell_init_file }}"
     line: . {{ nvm_install_path }}/nvm.sh
     create: yes
   tags: nvm
 
 - name: Install Node.js {{ nvm_node_version }}
-  shell: . ~/.profile && nvm install {{ nvm_node_version }}
+  shell: . {{ nvm_shell_init_file }} && nvm install {{ nvm_node_version }}
   register: nvm_install_result
   changed_when: "'is already installed.' not in nvm_install_result.stderr"
   tags: nvm
 
 - name: Check if {{ nvm_node_version }} is the default Node.js version
-  shell: . ~/.profile && nvm ls --no-colors | grep -e 'default -> {{ nvm_node_version }}'
+  shell: . {{ nvm_shell_init_file }} && nvm ls --no-colors | grep -e 'default -> {{ nvm_node_version }}'
   register: nvm_check_default
   changed_when: False
   failed_when: False
   tags: nvm
 
 - name: Set default Node.js version to {{ nvm_node_version }}
-  shell: . ~/.profile && nvm alias default {{ nvm_node_version }}
+  shell: . {{ nvm_shell_init_file }} && nvm alias default {{ nvm_node_version }}
   when: nvm_check_default.rc != 0
   tags: nvm


### PR DESCRIPTION
On my system, `~/.bash_profile` was auto-created and `~/.profile` was not sourced, so I made this a variable that can be changed.