### PR TITLE
git clone workaround

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,6 @@ nvm_install_deps: true
 
 # allow to change git url for use proxy
 nvm_git_repository: https://github.com/creationix/nvm.git
+
+# disable git recursive clone
+nvm_git_recursive: false

--- a/tasks/install_nvm.yml
+++ b/tasks/install_nvm.yml
@@ -2,6 +2,7 @@
 - name: Install nvm {{ nvm_version }}
   ansible.builtin.git:
     repo: "{{ nvm_git_repository }}"
+    recursive: "{{ nvm_git_recursive }}"
     dest: "{{ nvm_install_path }}"
     version: "v{{ nvm_version }}"
     force: "{{ nvm_force_install | bool }}"
@@ -10,6 +11,7 @@
 - name: Install nvm latest
   ansible.builtin.git:
     repo: "{{ nvm_git_repository }}"
+    recursive: "{{ nvm_git_recursive }}"
     dest: "{{ nvm_install_path }}"
     version: "{% if nvm_version == 'latest' %}master{% else %}{{ nvm_version }}{% endif %}"
     force: "{{ nvm_force_install | bool }}"


### PR DESCRIPTION
## Background

A few days ago there was a `.gitmodules` file added to the official nvm repository:
- https://github.com/nvm-sh/nvm/commit/29dce5edfd0976f9a1728c5746715c24061fd404#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584

Unfortunately the URL used in that submodule is apparently not publicly accessible:

```sh
$ git clone git@github.com:nvm-sh/nvmrc.git /tmp/nvmrc

Cloning into '/tmp/nvmrc'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

```sh
$ gh repo clone git@github.com:nvm-sh/nvmrc.git /tmp/nvmrc

Cloning into '/tmp/nvmrc'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
failed to run git: exit status 128
```

The problem for us is that for some reason the default value of `ansible.builtin.git.recursive` is `true` (which means all submodules will also be cloned):
- https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/git.py#L150-L156

## Solution

Therefore an obvious workaround is to simply set `recursive` to `false` - which is all this PR does...

To me it seems strange that the default behavior for the built-in `git` module is to do a recursive clone... though I highly doubt they would be willing to change that default value to `false`. Doing so would likely break git clone tasks for a large amount of people who depend on it implicitly.

We could also reach out to the `nvm` team to see if they could use a public repo URL for their submodule config...

Not sure what else we could do for a proper solution here.